### PR TITLE
remove dependencies from metadata.txt

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -6,4 +6,3 @@ version=0.1.1
 author=Maurice de Kleijn, Christiaan Meijer, Ou Ku
 email=c.meijer@esciencecenter.nl
 category=Analysis
-plugin_dependencies=geopandas,rioxarray,scikit-learn,dask


### PR DESCRIPTION
This gets rid of the confusing message during installation in QGIS asking for the user to 'manually' take care of these dependencies.